### PR TITLE
Linux対応、並びにREADME.mdの追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ start /min cmd /c npm run start
 
 ## Linuxの場合
 
+Linux(Steam Deck等)で使用する場合、別途exiftoolのインストールが必要になります。  
+ディストリビューションごとに適切なパッケージをインストールしてください。
+
+```shell
+# Ubuntu
+$ sudo apt install libimage-exiftool-perl
+
+# Arch Linux
+$ sudo pacman -S perl-image-exiftool
+```
+
 Linuxの場合、ターミナルを起動し、以下のコマンドを入力します。  
 (先頭の$は不要です)
 
@@ -100,17 +111,6 @@ $ npm install
 $ npm run tsc
 $ npm run start
 # Start VRChat
-```
-
-Linux(Steam Deck等)で使用する場合、別途exiftoolのインストールが必要になります。  
-ディストリビューションごとに適切なパッケージをインストールしてください。
-
-```shell
-# Ubuntu
-$ sudo apt install libimage-exiftool-perl
-
-# Arch Linux
-$ sudo pacman -S perl-image-exiftool
 ```
 
 また、VRChatのインストールパスがデフォルトでない場合、別途VRChatインストール先の`compatdata`ディレクトリを環境変数`STEAM_COMPAT_DATA_PATH`に指定する必要があります。

--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ VirtualLens2が有効な場合はさらに
 * 他の画像まわりのツール (特に、ログファイルを監視しファイルを移動するタイプのもの) とはおそらく干渉します
 * UDP#9001を占有します (OSCメッセージを受信して使うVRC拡張とは共存できません)
 
-Windows環境のみで動きます (PowerShell.exeが必要)
+Windows/Linux環境のみで動きます (Windowsの場合はPowerShell.exeが必要)
+
+# インストール
+
+Node.jsならびにnpmのインストールが必要です。  
+以下よりダウンロード、インストールを行ってください。
+
+[ダウンロード | Node.js](https://nodejs.org/ja/download/)
+
+パッケージマネージャによるインストールも可能です。  
+詳しくは以下を参考にしてください。
+
+[パッケージマネージャを利用した Node.js のインストール | Node.js](https://nodejs.org/ja/download/package-manager/)
+
+また、初回に`npm install`を実行する必要があります。
 
 # 使い方
 
@@ -29,3 +43,16 @@ Windows環境のみで動きます (PowerShell.exeが必要)
 > # Start VRChat
 ```
 
+# Linuxでの利用
+
+Linux(Steam Deck等)で使用する場合、別途exiftoolのインストールが必要になります。
+
+```shell
+# Debian / Ubuntu
+$ sudo apt install libimage-exiftool-perl
+
+# Arch Linux / Manjaro / SteamOS Holo
+$ sudo pacman -S perl-image-exiftool
+```
+
+また、VRChatのインストールパスがデフォルトでない場合、別途VRChatインストール先の`compatdata`ディレクトリを環境変数`STEAM_COMPAT_DATA_PATH`に指定する必要があります。

--- a/main.ts
+++ b/main.ts
@@ -73,7 +73,7 @@ function writeMetadata(file: string, data: MediaTag[], makerNotes?: MakerNotes) 
     execFile(process.platform == "win32" ? "./node_modules/exiftool.exe/vendor/exiftool.exe" : "exiftool", args).stdout?.on("data", (data: string) => {
         console.log(data);
     });
-    console.log("> " + process.platform == "win32" ? "./node_modules/exiftool.exe/vendor/exiftool.exe" : "exiftool" + args.join(" "));
+    console.log("> " + process.platform == "win32" ? "exiftool.exe" : "exiftool" + args.join(" "));
 }
 
 

--- a/main.ts
+++ b/main.ts
@@ -73,7 +73,7 @@ function writeMetadata(file: string, data: MediaTag[], makerNotes?: MakerNotes) 
     execFile(process.platform == "win32" ? "./node_modules/exiftool.exe/vendor/exiftool.exe" : "exiftool", args).stdout?.on("data", (data: string) => {
         console.log(data);
     });
-    console.log("> " + process.platform == "win32" ? "exiftool.exe" : "exiftool" + args.join(" "));
+    console.log("> " + process.platform == "win32" ? "exiftool.exe " : "exiftool" + args.join(" "));
 }
 
 

--- a/main.ts
+++ b/main.ts
@@ -141,7 +141,7 @@ class logReader {
     }
 
     open() {
-        const logDir = process.platform === "win32" ? `${process.env.APPDATA}\\..\\LocalLow\\VRChat\\VRChat\\` : `${compatdata_path}/438100/pfx/drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat/`;
+        const logDir = process.platform == "win32" ? `${process.env.APPDATA}\\..\\LocalLow\\VRChat\\VRChat\\` : `${compatdata_path}/438100/pfx/drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat/`;
 
         this.logFile = logDir + (fs.readdirSync(logDir)
             .filter(e => e.startsWith("output_log_"))


### PR DESCRIPTION
Steam Deck等のLinuxマシンに対応しました。(Arch Linux上で動作確認)
Linuxの場合、Steamの仕様上ログの保存先がVRChatのインストール先によって異なるため、環境変数で指定できる形式を取っています。
(Windowsで実行した場合、該当部分は空の文字列になります)

また、それに合わせREADME.mdの内容を更新、ついでにNode.jsのインストールに関する事項を追記しました。