### PR TITLE
Windows Defender Firewallのアクセス許可を取得できるように

### DIFF
--- a/utils/firewall-request.js
+++ b/utils/firewall-request.js
@@ -1,0 +1,4 @@
+import { Server } from 'node-osc';
+const s = new Server(9001, '127.0.0.2', () => {
+    s.close();
+});

--- a/utils/setup.ps1
+++ b/utils/setup.ps1
@@ -125,6 +125,10 @@ if ($isAutoStart) {
 }
 
 Write-Host "`nインストールされたフォルダは スタートメニュー「VRChat-Exif-Writerのフォルダを開く」から開くことができます。"
+
+Write-Host "`nWindows FirewallにNode.jsを追加します`n このアプリの機能のいくつかが Windows Defender ファイヤウォールでブロックされています というウィンドウが出てきた場合、 プライベート ネットワーク を選択して (デフォルトで選択されているはずです) アクセスを許可する をクリックしてください。"
+node .\utils\firewall-request.js
+
 Write-Host "セットアップが終了しました。`n更新は、ショートカット「setup」から実行できます。"
 
 if($null -eq $task) {


### PR DESCRIPTION
初回起動からタスクスケジューラを通すとNode.exeがWindows Defenderでユーザーから許可を取れずにサーバーになれなかった